### PR TITLE
Update RoleFilter.plugin.js

### DIFF
--- a/release/RoleFilter.plugin.js
+++ b/release/RoleFilter.plugin.js
@@ -708,7 +708,7 @@ module.exports = (() => {
         patchRoles() {
             const roleClass = DiscordClassModules.PopoutRoles["role"];
 
-            if(!roleClass.includes("interactive")) {
+            if(!roleClass?.includes("interactive")) {
                 DiscordClassModules.PopoutRoles["role"] += " interactive";
             }
         }


### PR DESCRIPTION
Initialize the value to an empty array, `roleClass`, before calling the includes() method and check that the value is of the correct type.